### PR TITLE
add `showframe` option

### DIFF
--- a/preprint.cls
+++ b/preprint.cls
@@ -21,6 +21,9 @@
 \newif\iflinenumbers\linenumbersfalse
 \DeclareOption{linenumbers}{\linenumberstrue}
 
+\newif\ifshowframe\showframefalse
+\DeclareOption{showframe}{\showframetrue}
+
 \DeclareOption*{\PassOptionsToClass{\CurrentOption}{scrartcl}}
 \ProcessOptions\relax
 \iftwocolumn
@@ -235,7 +238,12 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % Geometry of page.
-\RequirePackage{geometry}
+\ifshowframe
+    \RequirePackage[showframe=true]{geometry}
+\else
+    \RequirePackage{geometry}
+\fi
+
 \if@twocolumn
   \geometry{left = 1.5cm, right = 1.5cm, top = 3.0cm, bottom = 3.0cm}
   \setlength{\columnsep}{1.25\baselineskip}

--- a/preprint.cls
+++ b/preprint.cls
@@ -239,7 +239,11 @@
 
 % Geometry of page.
 \ifshowframe
+  \ifdefined\tikzexternalrealjob
+    \RequirePackage[showframe=false]{geometry}
+  \else
     \RequirePackage[showframe=true]{geometry}
+  \fi
 \else
     \RequirePackage{geometry}
 \fi


### PR DESCRIPTION
I'm not sure if this is useful to anyone else but I've added a `showframe` option to the class with which one can display the page boundaries. I use this for typesetting and check for any violations.